### PR TITLE
Fix Task 4 description

### DIFF
--- a/sequence_translate.py
+++ b/sequence_translate.py
@@ -10,7 +10,7 @@
 ## 1. Document Dr. X's function with comments and with markdown text in your Jupyter notebook.
 ## 2. Write a function that translates a string of nucleotides to amino acids based on Dr. X's pseudo-code suggestion.
 ## 3. Write an alternative translation function.
-## 4. Write a function that calculates the molecular weight of each 3 amino acid sequence.
+## 4. Write a function that calculates the molecular weight of each amino acid sequence.
 ## 5. Write a function that computes the GC-content of each DNA sequence.
 
 #-- In the MAIN part of the script --#


### PR DESCRIPTION
## Summary
- update Task 4 description in sequence_translate.py so it no longer mentions "3" amino acid sequences

## Testing
- `python -m py_compile sequence_translate.py`

------
https://chatgpt.com/codex/tasks/task_e_684060b0bc688330b21f863fc1103c3e